### PR TITLE
Split up main dialogs into separate files

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,14 @@
 const fs      = require('fs');
+
+const _       = require('lodash');
 const restify = require('restify');
 const builder = require('botbuilder');
 
 const config = fs.existsSync('./config/index.js') ? require('./config') : {};
+
+const NearbyDialog = require('./dialogs/nearby');
+const ReportDialog = require('./dialogs/report');
+const TrackDialog  = require('./dialogs/track');
 
 //=========================================================
 // Bot Setup
@@ -47,8 +53,22 @@ bot.dialog('/', [
         ]);
     },
     function (session, results) {
-        if (results.response) {
-            session.send(results.response.entity);
+        const mainDialogs = {
+            "nearby_choice": "/nearby",
+            "report_choice": "/report",
+            "track_choice" : "/track"
+        };
+        const mainChoice = _.get(results, 'response.entity');
+        const nextDialog = mainDialogs[mainChoice];
+
+        if (nextDialog) {
+            session.beginDialog(nextDialog);
+        } else {
+            session.send("generic_error");
         }
     }
 ]);
+
+bot.dialog('/nearby', NearbyDialog);
+bot.dialog('/report', ReportDialog);
+bot.dialog('/track', TrackDialog);

--- a/dialogs/nearby.js
+++ b/dialogs/nearby.js
@@ -1,0 +1,5 @@
+module.exports = [
+    function (session) {
+        session.send("TODO: Build the nearby issues dialog!");
+    }
+];

--- a/dialogs/report.js
+++ b/dialogs/report.js
@@ -1,0 +1,5 @@
+module.exports = [
+    function (session) {
+        session.send("TODO: Build the report issues dialog!");
+    }
+];

--- a/dialogs/track.js
+++ b/dialogs/track.js
@@ -1,0 +1,5 @@
+module.exports = [
+    function (session) {
+        session.send("TODO: Build the track issues dialog!");
+    }
+];

--- a/locale/en/index.json
+++ b/locale/en/index.json
@@ -2,5 +2,6 @@
     "initial_prompt": "What would you like to do today?",
     "nearby_choice": "See nearby issues",
     "report_choice": "Report an issue",
-    "track_choice": "Track an issue"
+    "track_choice": "Track an issue",
+    "generic_error": "I didn't understand what you said. Try again?"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "botbuilder": "^3.4.4",
+    "lodash": "^4.17.2",
     "restify": "^4.3.0"
   }
 }


### PR DESCRIPTION
Quick pull request before I head out for the night. :beers:

This splits up the Open 311 dialog into three main parts, so they're handled in separate files.

- "/nearby" maps to `dialogs/nearby.js`
    - This is the chat dialog that looks at all of the issues around you.
- "/report" maps to `dialogs/report.js`
    - This is the chat dialog where you can report an issue.
- "/track" maps to `dialogs/track.js`
    - This is the chat dialog where you can track your open issues.

We can start working on these separately, but just wanted to give a sense of what the structure of the chatbot will be like.

PTAL @3vivekb @arichen @ChristaCode 